### PR TITLE
fix dockerfile on non-m2 systems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,12 +28,12 @@ RUN apt-get update && apt-get install -y \
 
 # Download the libwasmvm.aarch64.so file directly from GitHub
 WORKDIR /tmp
-RUN wget https://github.com/CosmWasm/wasmvm/releases/download/v2.1.4/libwasmvm.aarch64.so \
-    -O /usr/local/lib/libwasmvm.aarch64.so && \
-    chmod 755 /usr/local/lib/libwasmvm.aarch64.so
+RUN wget https://github.com/CosmWasm/wasmvm/releases/download/v2.1.4/libwasmvm.`uname -m`.so \
+    -O /usr/local/lib/libwasmvm.`uname -m`.so && \
+    chmod 755 /usr/local/lib/libwasmvm.`uname -m`.so
 
 # Update the linker cache
-RUN ldconfig
+RUN ldconfig /usr/local/lib/
 
 # Set the working directory
 WORKDIR /root/


### PR DESCRIPTION
Instead of always using `aarch64`, Docker now downloads `libwasmvm.x86_64.so` for x86 systems.

Additionally, this explicitly specifies the path for `ldconfig` to update. It seems necessary for my system (Debian 12, Docker 20.10.24, ldconfig 2.36). 

This should not break any existing functionality.