### PR TITLE
relay buy storage events from evm to jackal

### DIFF
--- a/forge/src/Jackal.sol
+++ b/forge/src/Jackal.sol
@@ -64,9 +64,11 @@ abstract contract Jackal {
         validAddress
         hasAllowance(from)
     {
-        require(expires >= 30);
-        uint256 pE = getStoragePrice(filesize, 2400); // 12 * 200 months
-        require(msg.value >= pE, string.concat("Insufficient payment, need ", Strings.toString(pE), " wei"));
+        require(expires >= 30 || expires == 0);
+        if (expires != 0) {
+            uint256 pE = getStoragePrice(filesize, 2400); // 12 * 200 months
+            require(msg.value >= pE, string.concat("Insufficient payment, need ", Strings.toString(pE), " wei"));
+        }
         emit PostedFile(from, merkle, filesize, note, expires);
     }
 

--- a/forge/src/Jackal.sol
+++ b/forge/src/Jackal.sol
@@ -64,6 +64,7 @@ abstract contract Jackal {
         validAddress
         hasAllowance(from)
     {
+        require(expires >= 30);
         uint256 pE = getStoragePrice(filesize, 2400); // 12 * 200 months
         require(msg.value >= pE, string.concat("Insufficient payment, need ", Strings.toString(pE), " wei"));
         emit PostedFile(from, merkle, filesize, note, expires);

--- a/forge/src/Jackal.sol
+++ b/forge/src/Jackal.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 
 abstract contract Jackal {
-    event PostedFile(address sender, string merkle, uint64 size);
+    event PostedFile(address sender, string merkle, uint64 size, string note);
     event BoughtStorage(address from, string for_address, uint64 duration_days, uint64 size_bytes, string referral);
 
     function getPrice() public view virtual returns (int256);
@@ -58,7 +58,7 @@ abstract contract Jackal {
         return p;
     }
 
-    function postFileFrom(address from, string memory merkle, uint64 filesize)
+    function postFileFrom(address from, string memory merkle, uint64 filesize, string memory note)
         public
         payable
         validAddress
@@ -66,11 +66,11 @@ abstract contract Jackal {
     {
         uint256 pE = getStoragePrice(filesize, 2400); // 12 * 200 months
         require(msg.value >= pE, string.concat("Insufficient payment, need ", Strings.toString(pE), " wei"));
-        emit PostedFile(from, merkle, filesize);
+        emit PostedFile(from, merkle, filesize, note);
     }
 
-    function postFile(string memory merkle, uint64 filesize) public payable {
-        postFileFrom(msg.sender, merkle, filesize);
+    function postFile(string memory merkle, uint64 filesize, string memory note) public payable {
+        postFileFrom(msg.sender, merkle, filesize, note);
     }
 
     function buyStorageFrom(

--- a/forge/src/Jackal.sol
+++ b/forge/src/Jackal.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 
 abstract contract Jackal {
-    event PostedFile(address sender, string merkle, uint64 size, string note);
+    event PostedFile(address sender, string merkle, uint64 size, string note, uint64 expires);
     event BoughtStorage(address from, string for_address, uint64 duration_days, uint64 size_bytes, string referral);
 
     function getPrice() public view virtual returns (int256);
@@ -58,7 +58,7 @@ abstract contract Jackal {
         return p;
     }
 
-    function postFileFrom(address from, string memory merkle, uint64 filesize, string memory note)
+    function postFileFrom(address from, string memory merkle, uint64 filesize, string memory note, uint64 expires)
         public
         payable
         validAddress
@@ -66,11 +66,11 @@ abstract contract Jackal {
     {
         uint256 pE = getStoragePrice(filesize, 2400); // 12 * 200 months
         require(msg.value >= pE, string.concat("Insufficient payment, need ", Strings.toString(pE), " wei"));
-        emit PostedFile(from, merkle, filesize, note);
+        emit PostedFile(from, merkle, filesize, note, expires);
     }
 
-    function postFile(string memory merkle, uint64 filesize, string memory note) public payable {
-        postFileFrom(msg.sender, merkle, filesize, note);
+    function postFile(string memory merkle, uint64 filesize, string memory note, uint64 expires) public payable {
+        postFileFrom(msg.sender, merkle, filesize, note, expires);
     }
 
     function buyStorageFrom(

--- a/forge/src/JackalInterface.sol
+++ b/forge/src/JackalInterface.sol
@@ -2,8 +2,8 @@
 pragma solidity ^0.8.26;
 
 interface JackalInterface {
-    function postFile(string memory merkle, uint64 filesize) external payable;
-    function postFileFrom(address from, string memory merkle, uint64 filesize) external payable;
+    function postFile(string memory merkle, uint64 filesize, string memory note) external payable;
+    function postFileFrom(address from, string memory merkle, uint64 filesize, string memory note) external payable;
     function buyStorage(string memory for_address, uint64 duration_days, uint64 size_bytes, string memory referral)
         external
         payable;

--- a/forge/src/JackalInterface.sol
+++ b/forge/src/JackalInterface.sol
@@ -4,8 +4,14 @@ pragma solidity ^0.8.26;
 interface JackalInterface {
     function postFile(string memory merkle, uint64 filesize) external payable;
     function postFileFrom(address from, string memory merkle, uint64 filesize) external payable;
-    function buyStorage(string memory for_address, uint64 duration_days, uint64 size_bytes) external payable;
-    function buyStorageFrom(address from, string memory for_address, uint64 duration_days, uint64 size_bytes)
+    function buyStorage(string memory for_address, uint64 duration_days, uint64 size_bytes, string memory referral)
         external
         payable;
+    function buyStorageFrom(
+        address from,
+        string memory for_address,
+        uint64 duration_days,
+        uint64 size_bytes,
+        string memory referral
+    ) external payable;
 }

--- a/forge/src/JackalInterface.sol
+++ b/forge/src/JackalInterface.sol
@@ -2,8 +2,10 @@
 pragma solidity ^0.8.26;
 
 interface JackalInterface {
-    function postFile(string memory merkle, uint64 filesize, string memory note) external payable;
-    function postFileFrom(address from, string memory merkle, uint64 filesize, string memory note) external payable;
+    function postFile(string memory merkle, uint64 filesize, string memory note, uint64 expires) external payable;
+    function postFileFrom(address from, string memory merkle, uint64 filesize, string memory note, uint64 expires)
+        external
+        payable;
     function buyStorage(string memory for_address, uint64 duration_days, uint64 size_bytes, string memory referral)
         external
         payable;

--- a/forge/src/JackalInterface.sol
+++ b/forge/src/JackalInterface.sol
@@ -4,4 +4,8 @@ pragma solidity ^0.8.26;
 interface JackalInterface {
     function postFile(string memory merkle, uint64 filesize) external payable;
     function postFileFrom(address from, string memory merkle, uint64 filesize) external payable;
+    function buyStorage(string memory for_address, uint64 duration_days, uint64 size_bytes) external payable;
+    function buyStorageFrom(address from, string memory for_address, uint64 duration_days, uint64 size_bytes)
+        external
+        payable;
 }

--- a/forge/src/JackalV1.sol
+++ b/forge/src/JackalV1.sol
@@ -6,12 +6,11 @@ import {AggregatorV3Interface} from "@chainlink/interfaces/feeds/AggregatorV3Int
 import {Jackal} from "./Jackal.sol";
 
 contract JackalBridge is Ownable, Jackal {
-
     AggregatorV3Interface internal priceFeed;
 
     address[] public relays;
 
-    constructor(address[] memory _relays, address _priceFeed) Ownable(msg.sender){
+    constructor(address[] memory _relays, address _priceFeed) Ownable(msg.sender) {
         require(_relays.length > 0, "must provide relays");
 
         priceFeed = AggregatorV3Interface(_priceFeed);
@@ -25,7 +24,7 @@ contract JackalBridge is Ownable, Jackal {
     }
 
     function isRelay(address _relay) internal view returns (bool) {
-        for (uint i = 0; i < relays.length; i++) {
+        for (uint256 i = 0; i < relays.length; i++) {
             if (relays[i] == _relay) {
                 return true;
             }
@@ -40,20 +39,16 @@ contract JackalBridge is Ownable, Jackal {
 
     // Function to remove a relay, only callable by the owner
     function removeRelay(address _relay) public onlyOwner {
-
         require(relays.length > 1); // require there to be at least one relay in the list after removal
 
-        for (uint i = 0; i < relays.length; i++) {
+        for (uint256 i = 0; i < relays.length; i++) {
             if (relays[i] == _relay) {
                 relays[i] = relays[relays.length - 1];
                 relays.pop();
                 break;
             }
         }
-
     }
-
-
 
     function distributeBalance() public onlyOwnerOrRelay {
         uint256 balance = address(this).balance;
@@ -65,16 +60,13 @@ contract JackalBridge is Ownable, Jackal {
         uint256 relayShare = balance - ownerShare; // Remaining 50%
         uint256 perRelay = relayShare / relays.length;
 
-        for (uint i = 0; i < relays.length; i++) {
+        for (uint256 i = 0; i < relays.length; i++) {
             payable(relays[i]).transfer(perRelay);
         }
-
     }
 
-    function getPrice() public override view returns (int) {
-        (,int price,,,) = priceFeed.latestRoundData();
+    function getPrice() public view override returns (int256) {
+        (, int256 price,,,) = priceFeed.latestRoundData();
         return price;
     }
-
-
 }

--- a/forge/src/StorageDrawer.sol
+++ b/forge/src/StorageDrawer.sol
@@ -4,12 +4,11 @@ pragma solidity ^0.8.26;
 import {JackalInterface} from "./JackalInterface.sol";
 
 contract StorageDrawer {
-
     JackalInterface internal jackalBridge;
 
     mapping(address => string[]) public cabinet;
 
-    constructor(address _jackalAddress){
+    constructor(address _jackalAddress) {
         jackalBridge = JackalInterface(_jackalAddress);
     }
 
@@ -18,12 +17,12 @@ contract StorageDrawer {
         cabinet[msg.sender].push(merkle);
     }
 
-    function fileAddress(address _addr, uint _index) public view returns (string memory){
+    function fileAddress(address _addr, uint256 _index) public view returns (string memory) {
         require(_index < cabinet[_addr].length);
         return cabinet[_addr][_index];
     }
 
-    function fileCount(address _addr) public view returns (uint){
+    function fileCount(address _addr) public view returns (uint256) {
         return cabinet[_addr].length;
     }
 }

--- a/relay/abi.go
+++ b/relay/abi.go
@@ -65,7 +65,12 @@ func generatePostedFileMsg(w *wallet.Wallet, q *uploader.Queue, chainID uint64, 
 	fileSize := int64(event.Size)
 
 	note := make(map[string]any)
-	json.Unmarshal([]byte(event.Note), &note)
+	err = json.Unmarshal([]byte(event.Note), &note)
+	if err != nil && event.Note != "" {
+		log.Printf("Could not unmarshal: %v", err)
+		return
+	}
+
 	note["relayed"] = map[string]any{"chain_id": chainRep(chainID), "for": evmAddress}
 	newNote, err := json.Marshal(note)
 	if err != nil {

--- a/relay/abi.go
+++ b/relay/abi.go
@@ -2,12 +2,13 @@ package relay
 
 import (
 	"context"
-	_ "embed"
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
 	"log"
 	"strings"
+
+	_ "embed"
 
 	"github.com/CosmWasm/wasmd/x/wasm"
 	"github.com/JackalLabs/mulberry/jackal/uploader"
@@ -19,51 +20,10 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
-var ABI = `[
-    {
-      "type": "function",
-      "name": "postFile",
-      "inputs": [
-        {
-          "name": "merkle",
-          "type": "string",
-          "internalType": "string"
-        },
-        {
-          "name": "filesize",
-          "type": "uint64",
-          "internalType": "uint64"
-        }
-      ],
-      "outputs": [],
-      "stateMutability": "payable"
-    },
-    {
-      "type": "event",
-      "name": "PostedFile",
-      "inputs": [
-        {
-          "name": "sender",
-          "type": "address",
-          "indexed": false,
-          "internalType": "address"
-        },
-        {
-          "name": "merkle",
-          "type": "string",
-          "indexed": false,
-          "internalType": "string"
-        },
-        {
-          "name": "size",
-          "type": "uint64",
-          "indexed": false,
-          "internalType": "uint64"
-        }
-      ],
-      "anonymous": false
-    }
-  ]`
+//go:embed jackal.abi
+var ABI string
+
+// from `forge inspect Jackal abi`
 
 var eventABI abi.ABI
 

--- a/relay/abi.go
+++ b/relay/abi.go
@@ -98,8 +98,8 @@ func generateBoughtStorageMsg(w *wallet.Wallet, q *uploader.Queue, chainID uint6
 			ForAddress:   event.ForAddress,
 			DurationDays: int64(event.DurationDays),
 			Bytes:        int64(event.SizeBytes),
-			PaymentDenom: "eth",
-			Referral:     "mulberry relayer",
+			PaymentDenom: "ujkl",
+			Referral:     event.Referral,
 		},
 	}
 

--- a/relay/abi.go
+++ b/relay/abi.go
@@ -78,7 +78,10 @@ func generatePostedFileMsg(w *wallet.Wallet, q *uploader.Queue, chainID uint64, 
 	}
 
 	// calculate expires field (event.Expires is the number of days)
-	expires := abci.Response.LastBlockHeight + ((int64(event.Expires) * 24 * 60 * 60) / 6)
+	expires := int64(0)
+	if event.Expires != 0 {
+		expires = abci.Response.LastBlockHeight + ((int64(event.Expires) * 24 * 60 * 60) / 6)
+	}
 
 	storageMsg := evmTypes.ExecuteMsg{
 		PostFile: &evmTypes.ExecuteMsgPostFile{

--- a/relay/abi.json
+++ b/relay/abi.json
@@ -176,6 +176,11 @@
         "name": "note",
         "type": "string",
         "internalType": "string"
+      },
+      {
+        "name": "expires",
+        "type": "uint64",
+        "internalType": "uint64"
       }
     ],
     "outputs": [],
@@ -204,6 +209,11 @@
         "name": "note",
         "type": "string",
         "internalType": "string"
+      },
+      {
+        "name": "expires",
+        "type": "uint64",
+        "internalType": "uint64"
       }
     ],
     "outputs": [],
@@ -286,6 +296,12 @@
         "type": "string",
         "indexed": false,
         "internalType": "string"
+      },
+      {
+        "name": "expires",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
       }
     ],
     "anonymous": false

--- a/relay/jackal.abi
+++ b/relay/jackal.abi
@@ -1,0 +1,261 @@
+[
+  {
+    "type": "function",
+    "name": "addAllowance",
+    "inputs": [
+      {
+        "name": "allow",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "allowances",
+    "inputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "buyStorage",
+    "inputs": [
+      {
+        "name": "for_address",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "duration_days",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "size_bytes",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "buyStorageFrom",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "for_address",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "duration_days",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "size_bytes",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "getAllowance",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getPrice",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256",
+        "internalType": "int256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getStoragePrice",
+    "inputs": [
+      {
+        "name": "filesize",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "months",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "postFile",
+    "inputs": [
+      {
+        "name": "merkle",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "filesize",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "postFileFrom",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "merkle",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "filesize",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "removeAllowance",
+    "inputs": [
+      {
+        "name": "allow",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "BoughtStorage",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "for_address",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      },
+      {
+        "name": "duration_days",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      },
+      {
+        "name": "size_bytes",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "PostedFile",
+    "inputs": [
+      {
+        "name": "sender",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "merkle",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      },
+      {
+        "name": "size",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  }
+]

--- a/relay/jackal.abi
+++ b/relay/jackal.abi
@@ -54,6 +54,11 @@
         "name": "size_bytes",
         "type": "uint64",
         "internalType": "uint64"
+      },
+      {
+        "name": "referral",
+        "type": "string",
+        "internalType": "string"
       }
     ],
     "outputs": [],
@@ -82,6 +87,11 @@
         "name": "size_bytes",
         "type": "uint64",
         "internalType": "uint64"
+      },
+      {
+        "name": "referral",
+        "type": "string",
+        "internalType": "string"
       }
     ],
     "outputs": [],
@@ -161,6 +171,11 @@
         "name": "filesize",
         "type": "uint64",
         "internalType": "uint64"
+      },
+      {
+        "name": "note",
+        "type": "string",
+        "internalType": "string"
       }
     ],
     "outputs": [],
@@ -184,6 +199,11 @@
         "name": "filesize",
         "type": "uint64",
         "internalType": "uint64"
+      },
+      {
+        "name": "note",
+        "type": "string",
+        "internalType": "string"
       }
     ],
     "outputs": [],
@@ -229,6 +249,12 @@
         "type": "uint64",
         "indexed": false,
         "internalType": "uint64"
+      },
+      {
+        "name": "referral",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
       }
     ],
     "anonymous": false
@@ -254,6 +280,12 @@
         "type": "uint64",
         "indexed": false,
         "internalType": "uint64"
+      },
+      {
+        "name": "note",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
       }
     ],
     "anonymous": false

--- a/relay/types.go
+++ b/relay/types.go
@@ -32,4 +32,5 @@ type BoughtStorage struct {
 	ForAddress   string
 	DurationDays uint64
 	SizeBytes    uint64
+	Referral     string
 }

--- a/relay/types.go
+++ b/relay/types.go
@@ -25,6 +25,7 @@ type PostedFile struct {
 	Sender common.Address
 	Merkle string
 	Size   uint64
+	Note   string
 }
 
 type BoughtStorage struct {

--- a/relay/types.go
+++ b/relay/types.go
@@ -22,10 +22,11 @@ var ChainIDS = map[uint64]string{
 }
 
 type PostedFile struct {
-	Sender common.Address
-	Merkle string
-	Size   uint64
-	Note   string
+	Sender  common.Address
+	Merkle  string
+	Size    uint64
+	Note    string
+	Expires uint64
 }
 
 type BoughtStorage struct {

--- a/relay/types.go
+++ b/relay/types.go
@@ -4,6 +4,7 @@ import (
 	"github.com/JackalLabs/mulberry/config"
 	"github.com/JackalLabs/mulberry/jackal/uploader"
 	"github.com/desmos-labs/cosmos-go-wallet/wallet"
+	"github.com/ethereum/go-ethereum/common"
 )
 
 type App struct {
@@ -18,4 +19,17 @@ var ChainIDS = map[uint64]string{
 	137:   "Polygon",
 	10:    "OP",
 	42161: "Arbitrum",
+}
+
+type PostedFile struct {
+	Sender common.Address
+	Merkle string
+	Size   uint64
+}
+
+type BoughtStorage struct {
+	From         common.Address
+	ForAddress   string
+	DurationDays uint64
+	SizeBytes    uint64
 }

--- a/types/messages.go
+++ b/types/messages.go
@@ -1,8 +1,9 @@
 package types
 
 type ExecuteMsg struct {
-	PostKey  *ExecuteMsgPostKey  `json:"post_key,omitempty"`
-	PostFile *ExecuteMsgPostFile `json:"post_file,omitempty"`
+	PostKey    *ExecuteMsgPostKey    `json:"post_key,omitempty"`
+	PostFile   *ExecuteMsgPostFile   `json:"post_file,omitempty"`
+	BuyStorage *ExecuteMsgBuyStorage `json:"buy_storage,omitempty"`
 }
 
 type ExecuteMsgPostKey struct {
@@ -17,6 +18,15 @@ type ExecuteMsgPostFile struct {
 	MaxProofs     int64  `json:"max_proofs"`
 	Expires       int64  `json:"expires"`
 	Note          string `json:"note"`
+}
+
+type ExecuteMsgBuyStorage struct {
+	Creator      string `json:"creator,omitempty"`
+	ForAddress   string `json:"for_address,omitempty"`
+	DurationDays int64  `json:"duration_days,omitempty"`
+	Bytes        int64  `json:"bytes,omitempty"`
+	PaymentDenom string `json:"payment_denom,omitempty"`
+	Referral     string `json:"referral,omitempty"`
 }
 
 // ToString returns a string representation of the message


### PR DESCRIPTION
currently, mulberry only has the functionality to relay `postFile`. this PR extends that to `buyStorage` and refactors parts of the code to allow even more methods to be added in the future. 
- allows users to call events from evm by adding handler to `Jackal.sol` contract
- relays it to canine-chain through `abi.go` and `handleLog` 

existing functionality unchanged, new code tested at https://github.com/BiPhan4/ict-evm/pull/50