### PR TITLE
relay delete file events from evm to jackal

### DIFF
--- a/forge/src/Jackal.sol
+++ b/forge/src/Jackal.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 
 abstract contract Jackal {
-    event PostedFile(address sender, string merkle, uint64 size, string note, uint64 expires);
+    event PostedFile(address from, string merkle, uint64 size, string note, uint64 expires);
     event BoughtStorage(address from, string for_address, uint64 duration_days, uint64 size_bytes, string referral);
     event DeletedFile(address from, string merkle, uint64 start);
 

--- a/forge/src/Jackal.sol
+++ b/forge/src/Jackal.sol
@@ -6,6 +6,7 @@ import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 abstract contract Jackal {
     event PostedFile(address sender, string merkle, uint64 size, string note, uint64 expires);
     event BoughtStorage(address from, string for_address, uint64 duration_days, uint64 size_bytes, string referral);
+    event DeletedFile(address from, string merkle, uint64 start);
 
     function getPrice() public view virtual returns (int256);
 
@@ -93,5 +94,19 @@ abstract contract Jackal {
         payable
     {
         buyStorageFrom(msg.sender, for_address, duration_days, size_bytes, referral);
+    }
+
+    function deleteFileFrom(address from, string memory merkle, uint64 start)
+        public
+        payable
+        validAddress
+        hasAllowance(from)
+    {
+        // is file deletion free?
+        emit DeletedFile(from, merkle, start);
+    }
+
+    function deleteFile(string memory merkle, uint64 start) public payable {
+        deleteFileFrom(msg.sender, merkle, start);
     }
 }

--- a/forge/src/JackalInterface.sol
+++ b/forge/src/JackalInterface.sol
@@ -16,4 +16,6 @@ interface JackalInterface {
         uint64 size_bytes,
         string memory referral
     ) external payable;
+    function deleteFile(string memory merkle, uint64 start) external payable;
+    function deleteFileFrom(address from, string memory merkle, uint64 start) external payable;
 }

--- a/forge/src/StorageDrawer.sol
+++ b/forge/src/StorageDrawer.sol
@@ -13,7 +13,7 @@ contract StorageDrawer {
     }
 
     function upload(string memory merkle, uint64 filesize) public payable {
-        jackalBridge.postFileFrom{value: msg.value}(msg.sender, merkle, filesize);
+        jackalBridge.postFileFrom{value: msg.value}(msg.sender, merkle, filesize, "", 30);
         cabinet[msg.sender].push(merkle);
     }
 

--- a/relay/abi.go
+++ b/relay/abi.go
@@ -43,7 +43,7 @@ func init() {
 
 func generatePostedFileMsg(w *wallet.Wallet, q *uploader.Queue, chainID uint64, jackalContract string, event PostedFile) (err error) {
 	log.Printf("Event details: %+v", event)
-	evmAddress := event.Sender.String()
+	evmAddress := event.From.String()
 
 	merkleRoot, err := hex.DecodeString(event.Merkle)
 	if err != nil {
@@ -57,7 +57,7 @@ func generatePostedFileMsg(w *wallet.Wallet, q *uploader.Queue, chainID uint64, 
 		return
 	}
 
-	log.Printf("Relaying for %s\n", event.Sender.String())
+	log.Printf("Relaying for %s\n", event.From.String())
 
 	merkleBase64 := base64.StdEncoding.EncodeToString(merkleRoot)
 	var maxProofs int64 = 3

--- a/relay/abi.json
+++ b/relay/abi.json
@@ -340,7 +340,7 @@
     "name": "PostedFile",
     "inputs": [
       {
-        "name": "sender",
+        "name": "from",
         "type": "address",
         "indexed": false,
         "internalType": "address"

--- a/relay/abi.json
+++ b/relay/abi.json
@@ -99,6 +99,47 @@
   },
   {
     "type": "function",
+    "name": "deleteFile",
+    "inputs": [
+      {
+        "name": "merkle",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "start",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "deleteFileFrom",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "merkle",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "start",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
     "name": "getAllowance",
     "inputs": [
       {
@@ -265,6 +306,31 @@
         "type": "string",
         "indexed": false,
         "internalType": "string"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "DeletedFile",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "merkle",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      },
+      {
+        "name": "start",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
       }
     ],
     "anonymous": false

--- a/relay/types.go
+++ b/relay/types.go
@@ -36,3 +36,9 @@ type BoughtStorage struct {
 	SizeBytes    uint64
 	Referral     string
 }
+
+type DeletedFile struct {
+	From   common.Address
+	Merkle string
+	Start  uint64
+}

--- a/relay/types.go
+++ b/relay/types.go
@@ -22,7 +22,7 @@ var ChainIDS = map[uint64]string{
 }
 
 type PostedFile struct {
-	Sender  common.Address
+	From    common.Address
 	Merkle  string
 	Size    uint64
 	Note    string

--- a/types/messages.go
+++ b/types/messages.go
@@ -4,6 +4,7 @@ type ExecuteMsg struct {
 	PostKey    *ExecuteMsgPostKey    `json:"post_key,omitempty"`
 	PostFile   *ExecuteMsgPostFile   `json:"post_file,omitempty"`
 	BuyStorage *ExecuteMsgBuyStorage `json:"buy_storage,omitempty"`
+	DeleteFile *ExecuteMsgDeleteFile `json:"delete_file,omitempty"`
 }
 
 type ExecuteMsgPostKey struct {
@@ -27,6 +28,11 @@ type ExecuteMsgBuyStorage struct {
 	Bytes        int64  `json:"bytes,omitempty"`
 	PaymentDenom string `json:"payment_denom,omitempty"`
 	Referral     string `json:"referral,omitempty"`
+}
+
+type ExecuteMsgDeleteFile struct {
+	Merkle string `json:"merkle,omitempty"`
+	Start  int64  `json:"start,omitempty"`
 }
 
 // ToString returns a string representation of the message


### PR DESCRIPTION
after `postFile` and `buyStorage`, this PR extends mulberry relayer functionality to `deleteFile` 

existing functionality unchanged, no unit tests yet