### PR TITLE
relay request report form events from EVM to Jackal

### DIFF
--- a/forge/src/Jackal.sol
+++ b/forge/src/Jackal.sol
@@ -6,7 +6,7 @@ import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 abstract contract Jackal {
     event PostedFile(address sender, string merkle, uint64 size, string note, uint64 expires);
     event BoughtStorage(address from, string for_address, uint64 duration_days, uint64 size_bytes, string referral);
-    event RequestedReportform(address from, string prover, string merkle, string owner, uint64 start);
+    event RequestedReportForm(address from, string prover, string merkle, string owner, uint64 start);
 
     function getPrice() public view virtual returns (int256);
 
@@ -103,7 +103,7 @@ abstract contract Jackal {
         string memory owner,
         uint64 start
     ) public payable validAddress hasAllowance(from) {
-        emit RequestedReportform(from, prover, merkle, owner, start);
+        emit RequestedReportForm(from, prover, merkle, owner, start);
     }
 
     function requestReportForm(string memory prover, string memory merkle, string memory owner, uint64 start)

--- a/forge/src/Jackal.sol
+++ b/forge/src/Jackal.sol
@@ -6,6 +6,7 @@ import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 abstract contract Jackal {
     event PostedFile(address sender, string merkle, uint64 size, string note, uint64 expires);
     event BoughtStorage(address from, string for_address, uint64 duration_days, uint64 size_bytes, string referral);
+    event RequestedReportform(address from, string prover, string merkle, string owner, uint64 start);
 
     function getPrice() public view virtual returns (int256);
 
@@ -93,5 +94,22 @@ abstract contract Jackal {
         payable
     {
         buyStorageFrom(msg.sender, for_address, duration_days, size_bytes, referral);
+    }
+
+    function requestReportFormFrom(
+        address from,
+        string memory prover,
+        string memory merkle,
+        string memory owner,
+        uint64 start
+    ) public payable validAddress hasAllowance(from) {
+        emit RequestedReportform(from, prover, merkle, owner, start);
+    }
+
+    function requestReportForm(string memory prover, string memory merkle, string memory owner, uint64 start)
+        public
+        payable
+    {
+        requestReportFormFrom(msg.sender, prover, merkle, owner, start);
     }
 }

--- a/forge/src/JackalInterface.sol
+++ b/forge/src/JackalInterface.sol
@@ -16,4 +16,14 @@ interface JackalInterface {
         uint64 size_bytes,
         string memory referral
     ) external payable;
+    function requestReportForm(string memory prover, string memory merkle, string memory owner, uint64 start)
+        external
+        payable;
+    function requestReportFormFrom(
+        address from,
+        string memory prover,
+        string memory merkle,
+        string memory owner,
+        uint64 start
+    ) external payable;
 }

--- a/relay/abi.go
+++ b/relay/abi.go
@@ -134,6 +134,38 @@ func generateBoughtStorageMsg(w *wallet.Wallet, q *uploader.Queue, chainID uint6
 	return
 }
 
+func generateRequestedReportFormMsg(w *wallet.Wallet, q *uploader.Queue, chainID uint64, jackalContract string, event RequestedReportForm) (err error) {
+	log.Printf("Event details: %+v", event)
+	evmAddress := event.From.String()
+	log.Printf("Relaying for %s\n", event.From.String())
+
+	merkleRoot, err := hex.DecodeString(event.Merkle)
+	if err != nil {
+		log.Printf("Failed to decode merkle: %v", err)
+		return
+	}
+	merkleBase64 := base64.StdEncoding.EncodeToString(merkleRoot)
+
+	storageMsg := evmTypes.ExecuteMsg{
+		RequestReportForm: &evmTypes.ExecuteMsgRequestReportForm{
+			Prover: event.Prover,
+			Merkle: merkleBase64,
+			Owner:  "", // who is the owner?
+			Start:  int64(event.Start),
+		},
+	}
+
+	factoryMsg = evmTypes.ExecuteFactoryMsg{
+		CallBindings: &evmTypes.ExecuteMsgCallBindings{
+			EvmAddress: &evmAddress,
+			Msg:        &storageMsg,
+		},
+	}
+
+	cost = 0
+	return
+}
+
 func handleLog(vLog *types.Log, w *wallet.Wallet, q *uploader.Queue, chainID uint64, jackalContract string) {
 	/*
 		e, err := eventABI.Unpack("PostedFile", vLog.Data)
@@ -147,6 +179,7 @@ func handleLog(vLog *types.Log, w *wallet.Wallet, q *uploader.Queue, chainID uin
 	// can't if-elif-else or case-switch because we need logging
 	eventPostedFile := PostedFile{}
 	eventBoughtStorage := BoughtStorage{}
+	eventRequestedReportForm := RequestedReportForm{}
 
 	if errUnpack = eventABI.UnpackIntoInterface(&eventPostedFile, "PostedFile", vLog.Data); errUnpack == nil {
 		if errGenerate = generatePostedFileMsg(w, q, chainID, jackalContract, eventPostedFile); errGenerate == nil {
@@ -161,6 +194,13 @@ func handleLog(vLog *types.Log, w *wallet.Wallet, q *uploader.Queue, chainID uin
 		}
 	}
 	log.Printf("Failed to unpack log data into BuyStorage: %v  %v", errUnpack, errGenerate)
+
+	if errUnpack = eventABI.UnpackIntoInterface(&eventRequestedReportForm, "RequestedReportForm", vLog.Data); errUnpack == nil {
+		if errGenerate = generateRequestedReportFormMsg(w, q, chainID, jackalContract, eventRequestedReportForm); errGenerate == nil {
+			goto execute
+		}
+	}
+	log.Printf("Failed to unpack log data into RequestReportForm: %v  %v", errUnpack, errGenerate)
 
 	log.Fatalf("Failed to unpack log data into all event types: %v", errUnpack)
 	return

--- a/relay/abi.json
+++ b/relay/abi.json
@@ -369,7 +369,7 @@
   },
   {
     "type": "event",
-    "name": "RequestedReportform",
+    "name": "RequestedReportForm",
     "inputs": [
       {
         "name": "from",

--- a/relay/abi.json
+++ b/relay/abi.json
@@ -233,6 +233,67 @@
     "stateMutability": "nonpayable"
   },
   {
+    "type": "function",
+    "name": "requestReportForm",
+    "inputs": [
+      {
+        "name": "prover",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "merkle",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "owner",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "start",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "requestReportFormFrom",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "prover",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "merkle",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "owner",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "start",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
     "type": "event",
     "name": "BoughtStorage",
     "inputs": [
@@ -299,6 +360,43 @@
       },
       {
         "name": "expires",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RequestedReportform",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "prover",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      },
+      {
+        "name": "merkle",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      },
+      {
+        "name": "owner",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      },
+      {
+        "name": "start",
         "type": "uint64",
         "indexed": false,
         "internalType": "uint64"

--- a/relay/types.go
+++ b/relay/types.go
@@ -36,3 +36,10 @@ type BoughtStorage struct {
 	SizeBytes    uint64
 	Referral     string
 }
+
+type RequestedReportForm struct {
+	From   common.Address
+	Prover string
+	Merkle string
+	Start  uint64
+}

--- a/types/messages.go
+++ b/types/messages.go
@@ -22,7 +22,6 @@ type ExecuteMsgPostFile struct {
 }
 
 type ExecuteMsgBuyStorage struct {
-	Creator      string `json:"creator,omitempty"`
 	ForAddress   string `json:"for_address,omitempty"`
 	DurationDays int64  `json:"duration_days,omitempty"`
 	Bytes        int64  `json:"bytes,omitempty"`
@@ -31,11 +30,10 @@ type ExecuteMsgBuyStorage struct {
 }
 
 type ExecuteMsgRequestReportForm struct {
-	Creator string `json:"creator,omitempty"`
-	Prover  string `json:"prover,omitempty"`
-	Merkle  string `json:"merkle,omitempty"`
-	Owner   string `json:"owner,omitempty"`
-	Start   int64  `json:"start,omitempty"`
+	Prover string `json:"prover,omitempty"`
+	Merkle string `json:"merkle,omitempty"`
+	Owner  string `json:"owner,omitempty"`
+	Start  int64  `json:"start,omitempty"`
 }
 
 // ToString returns a string representation of the message

--- a/types/messages.go
+++ b/types/messages.go
@@ -1,9 +1,10 @@
 package types
 
 type ExecuteMsg struct {
-	PostKey    *ExecuteMsgPostKey    `json:"post_key,omitempty"`
-	PostFile   *ExecuteMsgPostFile   `json:"post_file,omitempty"`
-	BuyStorage *ExecuteMsgBuyStorage `json:"buy_storage,omitempty"`
+	PostKey           *ExecuteMsgPostKey           `json:"post_key,omitempty"`
+	PostFile          *ExecuteMsgPostFile          `json:"post_file,omitempty"`
+	BuyStorage        *ExecuteMsgBuyStorage        `json:"buy_storage,omitempty"`
+	RequestReportForm *ExecuteMsgRequestReportForm `json:"request_report_form,omitempty"`
 }
 
 type ExecuteMsgPostKey struct {
@@ -27,6 +28,14 @@ type ExecuteMsgBuyStorage struct {
 	Bytes        int64  `json:"bytes,omitempty"`
 	PaymentDenom string `json:"payment_denom,omitempty"`
 	Referral     string `json:"referral,omitempty"`
+}
+
+type ExecuteMsgRequestReportForm struct {
+	Creator string `json:"creator,omitempty"`
+	Prover  string `json:"prover,omitempty"`
+	Merkle  string `json:"merkle,omitempty"`
+	Owner   string `json:"owner,omitempty"`
+	Start   int64  `json:"start,omitempty"`
 }
 
 // ToString returns a string representation of the message


### PR DESCRIPTION
draft, no tests yet 

this PR extends mulberry relayer functionality to `requestReportForm`

i know there's some redundant code especially with this and https://github.com/JackalLabs/mulberry/pull/17, but I plan on refactoring PR after both are merged