### PR TITLE
relay postKey from evm to jackal 

### DIFF
--- a/forge/src/Jackal.sol
+++ b/forge/src/Jackal.sol
@@ -8,6 +8,7 @@ abstract contract Jackal {
     event BoughtStorage(address from, string for_address, uint64 duration_days, uint64 size_bytes, string referral);
     event DeletedFile(address from, string merkle, uint64 start);
     event RequestedReportForm(address from, string prover, string merkle, string owner, uint64 start);
+    event PostedKey(address from, string key);
 
     function getPrice() public view virtual returns (int256);
 
@@ -126,5 +127,13 @@ abstract contract Jackal {
         payable
     {
         requestReportFormFrom(msg.sender, prover, merkle, owner, start);
+    }
+
+    function postKeyFrom(address from, string memory key) public payable validAddress hasAllowance(from) {
+        emit PostedKey(from, key);
+    }
+
+    function postKey(string memory key) public payable {
+        postKeyFrom(msg.sender, key);
     }
 }

--- a/forge/src/Jackal.sol
+++ b/forge/src/Jackal.sol
@@ -98,17 +98,12 @@ abstract contract Jackal {
         buyStorageFrom(msg.sender, for_address, duration_days, size_bytes, referral);
     }
 
-    function deleteFileFrom(address from, string memory merkle, uint64 start)
-        public
-        payable
-        validAddress
-        hasAllowance(from)
-    {
+    function deleteFileFrom(address from, string memory merkle, uint64 start) public validAddress hasAllowance(from) {
         // is file deletion free?
         emit DeletedFile(from, merkle, start);
     }
 
-    function deleteFile(string memory merkle, uint64 start) public payable {
+    function deleteFile(string memory merkle, uint64 start) public {
         deleteFileFrom(msg.sender, merkle, start);
     }
 
@@ -118,22 +113,19 @@ abstract contract Jackal {
         string memory merkle,
         string memory owner,
         uint64 start
-    ) public payable validAddress hasAllowance(from) {
+    ) public validAddress hasAllowance(from) {
         emit RequestedReportForm(from, prover, merkle, owner, start);
     }
 
-    function requestReportForm(string memory prover, string memory merkle, string memory owner, uint64 start)
-        public
-        payable
-    {
+    function requestReportForm(string memory prover, string memory merkle, string memory owner, uint64 start) public {
         requestReportFormFrom(msg.sender, prover, merkle, owner, start);
     }
 
-    function postKeyFrom(address from, string memory key) public payable validAddress hasAllowance(from) {
+    function postKeyFrom(address from, string memory key) public validAddress hasAllowance(from) {
         emit PostedKey(from, key);
     }
 
-    function postKey(string memory key) public payable {
+    function postKey(string memory key) public {
         postKeyFrom(msg.sender, key);
     }
 }

--- a/forge/src/JackalInterface.sol
+++ b/forge/src/JackalInterface.sol
@@ -2,13 +2,10 @@
 pragma solidity ^0.8.26;
 
 interface JackalInterface {
-    function postFile(string memory merkle, uint64 filesize, string memory note, uint64 expires) external payable;
     function postFileFrom(address from, string memory merkle, uint64 filesize, string memory note, uint64 expires)
         external
         payable;
-    function buyStorage(string memory for_address, uint64 duration_days, uint64 size_bytes, string memory referral)
-        external
-        payable;
+    function postFile(string memory merkle, uint64 filesize, string memory note, uint64 expires) external payable;
     function buyStorageFrom(
         address from,
         string memory for_address,
@@ -16,11 +13,11 @@ interface JackalInterface {
         uint64 size_bytes,
         string memory referral
     ) external payable;
-    function deleteFile(string memory merkle, uint64 start) external payable;
-    function deleteFileFrom(address from, string memory merkle, uint64 start) external payable;
-    function requestReportForm(string memory prover, string memory merkle, string memory owner, uint64 start)
+    function buyStorage(string memory for_address, uint64 duration_days, uint64 size_bytes, string memory referral)
         external
         payable;
+    function deleteFileFrom(address from, string memory merkle, uint64 start) external payable;
+    function deleteFile(string memory merkle, uint64 start) external payable;
     function requestReportFormFrom(
         address from,
         string memory prover,
@@ -28,4 +25,9 @@ interface JackalInterface {
         string memory owner,
         uint64 start
     ) external payable;
+    function requestReportForm(string memory prover, string memory merkle, string memory owner, uint64 start)
+        external
+        payable;
+    function postKey(string memory key) external payable;
+    function postKeyFrom(address from, string memory key) external payable;
 }

--- a/forge/src/JackalInterface.sol
+++ b/forge/src/JackalInterface.sol
@@ -16,18 +16,17 @@ interface JackalInterface {
     function buyStorage(string memory for_address, uint64 duration_days, uint64 size_bytes, string memory referral)
         external
         payable;
-    function deleteFileFrom(address from, string memory merkle, uint64 start) external payable;
-    function deleteFile(string memory merkle, uint64 start) external payable;
+    function deleteFileFrom(address from, string memory merkle, uint64 start) external;
+    function deleteFile(string memory merkle, uint64 start) external;
     function requestReportFormFrom(
         address from,
         string memory prover,
         string memory merkle,
         string memory owner,
         uint64 start
-    ) external payable;
+    ) external;
     function requestReportForm(string memory prover, string memory merkle, string memory owner, uint64 start)
-        external
-        payable;
-    function postKey(string memory key) external payable;
-    function postKeyFrom(address from, string memory key) external payable;
+        external;
+    function postKey(string memory key) external;
+    function postKeyFrom(address from, string memory key) external;
 }

--- a/relay/abi.go
+++ b/relay/abi.go
@@ -133,7 +133,7 @@ func generateDeletedFileMsg(q *uploader.Queue, event DeletedFile) (err error) {
 		},
 	}
 
-	cost = int64(float64(q.GetCost(0, 0)) * 1.2) // minimum nonzero cost
+	// cost = int64(float64(q.GetCost(0, 0)) * 1.2)
 	return
 }
 
@@ -167,7 +167,7 @@ func generatePostedKeyMsg(q *uploader.Queue, event PostedKey) (err error) {
 		},
 	}
 
-	cost = int64(float64(q.GetCost(0, 0)) * 1.2) // minimum nonzero cost
+	// cost = int64(float64(q.GetCost(0, 0)) * 1.2)
 	return
 }
 

--- a/relay/abi.json
+++ b/relay/abi.json
@@ -113,7 +113,7 @@
       }
     ],
     "outputs": [],
-    "stateMutability": "payable"
+    "stateMutability": "nonpayable"
   },
   {
     "type": "function",
@@ -136,7 +136,7 @@
       }
     ],
     "outputs": [],
-    "stateMutability": "payable"
+    "stateMutability": "nonpayable"
   },
   {
     "type": "function",
@@ -271,7 +271,7 @@
       }
     ],
     "outputs": [],
-    "stateMutability": "payable"
+    "stateMutability": "nonpayable"
   },
   {
     "type": "function",
@@ -289,7 +289,7 @@
       }
     ],
     "outputs": [],
-    "stateMutability": "payable"
+    "stateMutability": "nonpayable"
   },
   {
     "type": "function",
@@ -330,7 +330,7 @@
       }
     ],
     "outputs": [],
-    "stateMutability": "payable"
+    "stateMutability": "nonpayable"
   },
   {
     "type": "function",
@@ -363,7 +363,7 @@
       }
     ],
     "outputs": [],
-    "stateMutability": "payable"
+    "stateMutability": "nonpayable"
   },
   {
     "type": "event",

--- a/relay/abi.json
+++ b/relay/abi.json
@@ -262,6 +262,37 @@
   },
   {
     "type": "function",
+    "name": "postKey",
+    "inputs": [
+      {
+        "name": "key",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "postKeyFrom",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "key",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
     "name": "removeAllowance",
     "inputs": [
       {
@@ -429,6 +460,25 @@
         "type": "uint64",
         "indexed": false,
         "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "PostedKey",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "key",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
       }
     ],
     "anonymous": false

--- a/relay/types.go
+++ b/relay/types.go
@@ -50,3 +50,8 @@ type RequestedReportForm struct {
 	Owner  string
 	Start  uint64
 }
+
+type PostedKey struct {
+	From common.Address
+	Key  string
+}


### PR DESCRIPTION
after finishing storage module messages `postFile`, `buyStorage`, `deleteFile`, and `requestReportForm`, this PR implements handling for the first filetree module message `postKey`

intentionally kept simple to verify functionality