### PR TITLE
relay postFileTree from EVM to Jackal

### DIFF
--- a/forge/src/Jackal.sol
+++ b/forge/src/Jackal.sol
@@ -11,6 +11,16 @@ abstract contract Jackal {
     event PostedKey(address from, string key);
     event DeletedFileTree(address from, string hash_path, string account);
     event ProvisionedFileTree(address from, string editors, string viewers, string tracking_number);
+    event PostedFileTree(
+        address from,
+        string account,
+        string hash_parent,
+        string hash_child,
+        string contents,
+        string viewers,
+        string editors,
+        string tracking_number
+    );
 
     function getPrice() public view virtual returns (int256);
 
@@ -153,5 +163,31 @@ abstract contract Jackal {
 
     function provisionFileTree(string memory editors, string memory viewers, string memory tracking_number) public {
         provisionFileTreeFrom(msg.sender, editors, viewers, tracking_number);
+    }
+
+    function postFileTreeFrom(
+        address from,
+        string memory account,
+        string memory hash_parent,
+        string memory hash_child,
+        string memory contents,
+        string memory viewers,
+        string memory editors,
+        string memory tracking_number
+    ) public validAddress hasAllowance(from) {
+        // confirm postFileTree is free
+        emit PostedFileTree(from, account, hash_parent, hash_child, contents, viewers, editors, tracking_number);
+    }
+
+    function postFileTree(
+        string memory account,
+        string memory hash_parent,
+        string memory hash_child,
+        string memory contents,
+        string memory viewers,
+        string memory editors,
+        string memory tracking_number
+    ) public {
+        postFileTreeFrom(msg.sender, account, hash_parent, hash_child, contents, viewers, editors, tracking_number);
     }
 }

--- a/forge/src/JackalInterface.sol
+++ b/forge/src/JackalInterface.sol
@@ -38,4 +38,23 @@ interface JackalInterface {
         string memory viewers,
         string memory tracking_number
     ) external;
+    function postFileTree(
+        string memory account,
+        string memory hash_parent,
+        string memory hash_child,
+        string memory contents,
+        string memory viewers,
+        string memory editors,
+        string memory tracking_number
+    ) external;
+    function postFileTreeFrom(
+        address from,
+        string memory account,
+        string memory hash_parent,
+        string memory hash_child,
+        string memory contents,
+        string memory viewers,
+        string memory editors,
+        string memory tracking_number
+    ) external;
 }

--- a/relay/abi.go
+++ b/relay/abi.go
@@ -231,6 +231,13 @@ func handleLog(vLog *types.Log, w *wallet.Wallet, q *uploader.Queue, chainID uin
 	}
 	log.Printf("Failed to unpack log data into PostedFile: %v %v", errUnpack, errGenerate)
 
+	if errUnpack = eventABI.UnpackIntoInterface(&eventPostedFileTree, "PostedFileTree", vLog.Data); errUnpack == nil {
+		if errGenerate = generatePostedFileTreeMsg(eventPostedFileTree); errGenerate == nil {
+			goto execute
+		}
+	}
+	log.Printf("Failed to unpack log data into PostedFileTree: %v  %v", errUnpack, errGenerate)
+
 	if errUnpack = eventABI.UnpackIntoInterface(&eventBoughtStorage, "BoughtStorage", vLog.Data); errUnpack == nil {
 		if errGenerate = generateBoughtStorageMsg(q, eventBoughtStorage); errGenerate == nil {
 			goto execute
@@ -251,13 +258,6 @@ func handleLog(vLog *types.Log, w *wallet.Wallet, q *uploader.Queue, chainID uin
 		}
 	}
 	log.Printf("Failed to unpack log data into RequestedReportForm: %v  %v", errUnpack, errGenerate)
-
-	if errUnpack = eventABI.UnpackIntoInterface(&eventPostedFileTree, "PostedFileTree", vLog.Data); errUnpack == nil {
-		if errGenerate = generatePostedFileTreeMsg(eventPostedFileTree); errGenerate == nil {
-			goto execute
-		}
-	}
-	log.Printf("Failed to unpack log data into PostedFileTree: %v  %v", errUnpack, errGenerate)
 
 	if errUnpack = eventABI.UnpackIntoInterface(&eventProvisionedFileTree, "ProvisionedFileTree", vLog.Data); errUnpack == nil {
 		if errGenerate = generateProvisionedFiletreeMsg(eventProvisionedFileTree); errGenerate == nil {
@@ -309,7 +309,7 @@ execute:
 		return
 	}
 	if res == nil {
-		log.Fatalf("Response is empty")
+		log.Printf("Response is empty")
 		return
 	}
 

--- a/relay/abi.json
+++ b/relay/abi.json
@@ -303,6 +303,97 @@
   },
   {
     "type": "function",
+    "name": "postFileTree",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "hash_parent",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "hash_child",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "contents",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "viewers",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "editors",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "tracking_number",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "postFileTreeFrom",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "account",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "hash_parent",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "hash_child",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "contents",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "viewers",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "editors",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "tracking_number",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
     "name": "postKey",
     "inputs": [
       {
@@ -577,6 +668,61 @@
         "type": "uint64",
         "indexed": false,
         "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "PostedFileTree",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "account",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      },
+      {
+        "name": "hash_parent",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      },
+      {
+        "name": "hash_child",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      },
+      {
+        "name": "contents",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      },
+      {
+        "name": "viewers",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      },
+      {
+        "name": "editors",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      },
+      {
+        "name": "tracking_number",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
       }
     ],
     "anonymous": false

--- a/relay/types.go
+++ b/relay/types.go
@@ -68,3 +68,14 @@ type ProvisionedFileTree struct {
 	Viewers        string
 	TrackingNumber string
 }
+
+type PostedFileTree struct {
+	From           common.Address
+	Account        string
+	HashParent     string
+	HashChild      string
+	Contents       string
+	Viewers        string
+	Editors        string
+	TrackingNumber string
+}

--- a/types/messages.go
+++ b/types/messages.go
@@ -8,6 +8,7 @@ type ExecuteMsg struct {
 	RequestReportForm *ExecuteMsgRequestReportForm `json:"request_report_form,omitempty"`
 	DeleteFileTree    *ExecuteMsgDeleteFileTree    `json:"delete_file_tree,omitempty"`
 	ProvisionFileTree *ExecuteMsgProvisionFileTree `json:"provision_file_tree,omitempty"`
+	PostFileTree      *ExecuteMsgPostFileTree      `json:"post_file_tree,omitempty"`
 }
 
 type ExecuteMsgPostKey struct {
@@ -52,6 +53,16 @@ type ExecuteMsgDeleteFileTree struct {
 type ExecuteMsgProvisionFileTree struct {
 	Editors        string `json:"editors,omitempty"`
 	Viewers        string `json:"viewers,omitempty"`
+	TrackingNumber string `json:"tracking_number,omitempty"`
+}
+
+type ExecuteMsgPostFileTree struct {
+	Account        string `json:"account,omitempty"`
+	HashParent     string `json:"hash_parent,omitempty"`
+	HashChild      string `json:"hash_child,omitempty"`
+	Contents       string `json:"contents,omitempty"`
+	Viewers        string `json:"viewers,omitempty"`
+	Editors        string `json:"editors,omitempty"`
 	TrackingNumber string `json:"tracking_number,omitempty"`
 }
 

--- a/types/messages.go
+++ b/types/messages.go
@@ -26,44 +26,44 @@ type ExecuteMsgPostFile struct {
 }
 
 type ExecuteMsgBuyStorage struct {
-	ForAddress   string `json:"for_address,omitempty"`
-	DurationDays int64  `json:"duration_days,omitempty"`
-	Bytes        int64  `json:"bytes,omitempty"`
-	PaymentDenom string `json:"payment_denom,omitempty"`
-	Referral     string `json:"referral,omitempty"`
+	ForAddress   string `json:"for_address"`
+	DurationDays int64  `json:"duration_days"`
+	Bytes        int64  `json:"bytes"`
+	PaymentDenom string `json:"payment_denom"`
+	Referral     string `json:"referral"`
 }
 
 type ExecuteMsgDeleteFile struct {
-	Merkle string `json:"merkle,omitempty"`
-	Start  int64  `json:"start,omitempty"`
+	Merkle string `json:"merkle"`
+	Start  int64  `json:"start"`
 }
 
 type ExecuteMsgRequestReportForm struct {
-	Prover string `json:"prover,omitempty"`
-	Merkle string `json:"merkle,omitempty"`
-	Owner  string `json:"owner,omitempty"`
-	Start  int64  `json:"start,omitempty"`
+	Prover string `json:"prover"`
+	Merkle string `json:"merkle"`
+	Owner  string `json:"owner"`
+	Start  int64  `json:"start"`
 }
 
 type ExecuteMsgDeleteFileTree struct {
-	HashPath string `json:"hash_path,omitempty"`
-	Account  string `json:"account,omitempty"`
+	HashPath string `json:"hash_path"`
+	Account  string `json:"account"`
 }
 
 type ExecuteMsgProvisionFileTree struct {
-	Editors        string `json:"editors,omitempty"`
-	Viewers        string `json:"viewers,omitempty"`
-	TrackingNumber string `json:"tracking_number,omitempty"`
+	Editors        string `json:"editors"`
+	Viewers        string `json:"viewers"`
+	TrackingNumber string `json:"tracking_number"`
 }
 
 type ExecuteMsgPostFileTree struct {
-	Account        string `json:"account,omitempty"`
-	HashParent     string `json:"hash_parent,omitempty"`
-	HashChild      string `json:"hash_child,omitempty"`
-	Contents       string `json:"contents,omitempty"`
-	Viewers        string `json:"viewers,omitempty"`
-	Editors        string `json:"editors,omitempty"`
-	TrackingNumber string `json:"tracking_number,omitempty"`
+	Account        string `json:"account"`
+	HashParent     string `json:"hash_parent"`
+	HashChild      string `json:"hash_child"`
+	Contents       string `json:"contents"`
+	Viewers        string `json:"viewers"`
+	Editors        string `json:"editors"`
+	TrackingNumber string `json:"tracking_number"`
 }
 
 // ToString returns a string representation of the message


### PR DESCRIPTION
this PR passes the filetree message `postFileTree`, unit tests are a work in progress

please be extra careful reviewing—are we sure clients should do all the work (generating parent/child hash from file path) here?