### PR TITLE
relay changeOwner from EVM to Jackal

### DIFF
--- a/forge/src/Jackal.sol
+++ b/forge/src/Jackal.sol
@@ -76,6 +76,10 @@ abstract contract Jackal {
         return p;
     }
 
+    function postFile(string memory merkle, uint64 filesize, string memory note, uint64 expires) public payable {
+        postFileFrom(msg.sender, merkle, filesize, note, expires);
+    }
+
     function postFileFrom(address from, string memory merkle, uint64 filesize, string memory note, uint64 expires)
         public
         payable
@@ -90,8 +94,11 @@ abstract contract Jackal {
         emit PostedFile(from, merkle, filesize, note, expires);
     }
 
-    function postFile(string memory merkle, uint64 filesize, string memory note, uint64 expires) public payable {
-        postFileFrom(msg.sender, merkle, filesize, note, expires);
+    function buyStorage(string memory for_address, uint64 duration_days, uint64 size_bytes, string memory referral)
+        public
+        payable
+    {
+        buyStorageFrom(msg.sender, for_address, duration_days, size_bytes, referral);
     }
 
     function buyStorageFrom(
@@ -106,19 +113,16 @@ abstract contract Jackal {
         emit BoughtStorage(from, for_address, duration_days, size_bytes, referral);
     }
 
-    function buyStorage(string memory for_address, uint64 duration_days, uint64 size_bytes, string memory referral)
-        public
-        payable
-    {
-        buyStorageFrom(msg.sender, for_address, duration_days, size_bytes, referral);
+    function deleteFile(string memory merkle, uint64 start) public {
+        deleteFileFrom(msg.sender, merkle, start);
     }
 
     function deleteFileFrom(address from, string memory merkle, uint64 start) public validAddress hasAllowance(from) {
         emit DeletedFile(from, merkle, start); // file deletion is free
     }
 
-    function deleteFile(string memory merkle, uint64 start) public {
-        deleteFileFrom(msg.sender, merkle, start);
+    function requestReportForm(string memory prover, string memory merkle, string memory owner, uint64 start) public {
+        requestReportFormFrom(msg.sender, prover, merkle, owner, start);
     }
 
     function requestReportFormFrom(
@@ -131,16 +135,16 @@ abstract contract Jackal {
         emit RequestedReportForm(from, prover, merkle, owner, start);
     }
 
-    function requestReportForm(string memory prover, string memory merkle, string memory owner, uint64 start) public {
-        requestReportFormFrom(msg.sender, prover, merkle, owner, start);
+    function postKey(string memory key) public {
+        postKeyFrom(msg.sender, key);
     }
 
     function postKeyFrom(address from, string memory key) public validAddress hasAllowance(from) {
         emit PostedKey(from, key);
     }
 
-    function postKey(string memory key) public {
-        postKeyFrom(msg.sender, key);
+    function deleteFileTree(string memory hash_path, string memory account) public {
+        deleteFileTreeFrom(msg.sender, hash_path, account);
     }
 
     function deleteFileTreeFrom(address from, string memory hash_path, string memory account)
@@ -151,8 +155,8 @@ abstract contract Jackal {
         emit DeletedFileTree(from, hash_path, account);
     }
 
-    function deleteFileTree(string memory hash_path, string memory account) public {
-        deleteFileTreeFrom(msg.sender, hash_path, account);
+    function provisionFileTree(string memory editors, string memory viewers, string memory tracking_number) public {
+        provisionFileTreeFrom(msg.sender, editors, viewers, tracking_number);
     }
 
     function provisionFileTreeFrom(
@@ -164,8 +168,16 @@ abstract contract Jackal {
         emit ProvisionedFileTree(from, editors, viewers, tracking_number);
     }
 
-    function provisionFileTree(string memory editors, string memory viewers, string memory tracking_number) public {
-        provisionFileTreeFrom(msg.sender, editors, viewers, tracking_number);
+    function postFileTree(
+        string memory account,
+        string memory hash_parent,
+        string memory hash_child,
+        string memory contents,
+        string memory viewers,
+        string memory editors,
+        string memory tracking_number
+    ) public {
+        postFileTreeFrom(msg.sender, account, hash_parent, hash_child, contents, viewers, editors, tracking_number);
     }
 
     function postFileTreeFrom(
@@ -182,16 +194,13 @@ abstract contract Jackal {
         emit PostedFileTree(from, account, hash_parent, hash_child, contents, viewers, editors, tracking_number);
     }
 
-    function postFileTree(
-        string memory account,
-        string memory hash_parent,
-        string memory hash_child,
-        string memory contents,
-        string memory viewers,
-        string memory editors,
-        string memory tracking_number
+    function addViewers(
+        string memory viewer_ids,
+        string memory viewer_keys,
+        string memory for_address,
+        string memory file_owner
     ) public {
-        postFileTreeFrom(msg.sender, account, hash_parent, hash_child, contents, viewers, editors, tracking_number);
+        addViewersFrom(msg.sender, viewer_ids, viewer_keys, for_address, file_owner);
     }
 
     function addViewersFrom(
@@ -204,13 +213,8 @@ abstract contract Jackal {
         emit AddedViewers(from, viewer_ids, viewer_keys, for_address, file_owner);
     }
 
-    function addViewers(
-        string memory viewer_ids,
-        string memory viewer_keys,
-        string memory for_address,
-        string memory file_owner
-    ) public {
-        addViewersFrom(msg.sender, viewer_ids, viewer_keys, for_address, file_owner);
+    function removeViewers(string memory viewer_ids, string memory for_address, string memory file_owner) public {
+        removeViewersFrom(msg.sender, viewer_ids, for_address, file_owner);
     }
 
     function removeViewersFrom(
@@ -222,8 +226,8 @@ abstract contract Jackal {
         emit RemovedViewers(from, viewer_ids, for_address, file_owner);
     }
 
-    function removeViewers(string memory viewer_ids, string memory for_address, string memory file_owner) public {
-        removeViewersFrom(msg.sender, viewer_ids, for_address, file_owner);
+    function resetViewers(string memory for_address, string memory file_owner) public {
+        resetViewersFrom(msg.sender, for_address, file_owner);
     }
 
     function resetViewersFrom(address from, string memory for_address, string memory file_owner)
@@ -232,9 +236,5 @@ abstract contract Jackal {
         hasAllowance(from)
     {
         emit ResetViewers(from, for_address, file_owner);
-    }
-
-    function resetViewers(string memory for_address, string memory file_owner) public {
-        resetViewersFrom(msg.sender, for_address, file_owner);
     }
 }

--- a/forge/src/Jackal.sol
+++ b/forge/src/Jackal.sol
@@ -24,6 +24,7 @@ abstract contract Jackal {
     event AddedViewers(address from, string viewer_ids, string viewer_keys, string for_address, string file_owner);
     event RemovedViewers(address from, string viewer_ids, string for_address, string file_owner);
     event ResetViewers(address from, string for_address, string file_owner);
+    event ChangedOwner(address from, string for_address, string file_owner, string new_owner);
 
     function getPrice() public view virtual returns (int256);
 
@@ -190,7 +191,6 @@ abstract contract Jackal {
         string memory editors,
         string memory tracking_number
     ) public validAddress hasAllowance(from) {
-        // confirm postFileTree is free
         emit PostedFileTree(from, account, hash_parent, hash_child, contents, viewers, editors, tracking_number);
     }
 
@@ -236,5 +236,17 @@ abstract contract Jackal {
         hasAllowance(from)
     {
         emit ResetViewers(from, for_address, file_owner);
+    }
+
+    function changeOwner(string memory for_address, string memory file_owner, string memory new_owner) public {
+        changeOwnerFrom(msg.sender, for_address, file_owner, new_owner);
+    }
+
+    function changeOwnerFrom(address from, string memory for_address, string memory file_owner, string memory new_owner)
+        public
+        validAddress
+        hasAllowance(from)
+    {
+        emit ChangedOwner(from, for_address, file_owner, new_owner);
     }
 }

--- a/forge/src/JackalInterface.sol
+++ b/forge/src/JackalInterface.sol
@@ -79,4 +79,7 @@ interface JackalInterface {
     ) external;
     function resetViewers(string memory for_address, string memory file_owner) external;
     function resetViewersFrom(address from, string memory for_address, string memory file_owner) external;
+    function changeOwner(string memory for_address, string memory file_owner, string memory new_owner) external;
+    function changeOwnerFrom(address from, string memory for_address, string memory file_owner, string memory new_owner)
+        external;
 }

--- a/relay/abi.go
+++ b/relay/abi.go
@@ -255,6 +255,20 @@ func generateResetViewersMsg(event ResetViewers) (err error) {
 	return
 }
 
+func generateChangedOwnerMsg(event ChangedOwner) (err error) {
+	log.Printf("Event details: %+v", event)
+	evmAddress = event.From.String()
+
+	relayedMsg = evmTypes.ExecuteMsg{
+		ChangeOwner: &evmTypes.ExecuteMsgChangeOwner{
+			Address:   event.ForAddress,
+			FileOwner: event.FileOwner,
+			NewOwner:  event.NewOwner,
+		},
+	}
+	return
+}
+
 func handleLog(vLog *types.Log, w *wallet.Wallet, q *uploader.Queue, chainID uint64, jackalContract string) {
 	// https://goethereumbook.org/event-read/#topics
 	eventSig := vLog.Topics[0].Hex()
@@ -303,6 +317,10 @@ func handleLog(vLog *types.Log, w *wallet.Wallet, q *uploader.Queue, chainID uin
 		eventResetViewers := ResetViewers{}
 		errUnpack = eventABI.UnpackIntoInterface(&eventResetViewers, "ResetViewers", vLog.Data)
 		errGenerate = generateResetViewersMsg(eventResetViewers)
+	case expectedSig("ChangedOwner(address,string,string,string)"):
+		eventChangedOwner := ChangedOwner{}
+		errUnpack = eventABI.UnpackIntoInterface(&eventChangedOwner, "ChangedOwner", vLog.Data)
+		errGenerate = generateChangedOwnerMsg(eventChangedOwner)
 	default:
 		log.Fatal("Failed to unpack log data into any event type")
 	}

--- a/relay/abi.json
+++ b/relay/abi.json
@@ -160,6 +160,57 @@
   },
   {
     "type": "function",
+    "name": "changeOwner",
+    "inputs": [
+      {
+        "name": "for_address",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "file_owner",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "new_owner",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "changeOwnerFrom",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "for_address",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "file_owner",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "new_owner",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
     "name": "deleteFile",
     "inputs": [
       {
@@ -768,6 +819,37 @@
       },
       {
         "name": "referral",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ChangedOwner",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "for_address",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      },
+      {
+        "name": "file_owner",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      },
+      {
+        "name": "new_owner",
         "type": "string",
         "indexed": false,
         "internalType": "string"

--- a/relay/types.go
+++ b/relay/types.go
@@ -100,3 +100,10 @@ type ResetViewers struct {
 	ForAddress string
 	FileOwner  string
 }
+
+type ChangedOwner struct {
+	From       common.Address
+	ForAddress string
+	FileOwner  string
+	NewOwner   string
+}

--- a/types/messages.go
+++ b/types/messages.go
@@ -12,6 +12,7 @@ type ExecuteMsg struct {
 	AddViewers        *ExecuteMsgAddViewers        `json:"add_viewers,omitempty"`
 	RemoveViewers     *ExecuteMsgRemoveViewers     `json:"remove_viewers,omitempty"`
 	ResetViewers      *ExecuteMsgResetViewers      `json:"reset_viewers,omitempty"`
+	ChangeOwner       *ExecuteMsgChangeOwner       `json:"change_owner,omitempty"`
 }
 
 type ExecuteMsgPostKey struct {
@@ -85,6 +86,12 @@ type ExecuteMsgRemoveViewers struct {
 type ExecuteMsgResetViewers struct {
 	Address   string `json:"address"`
 	FileOwner string `json:"file_owner"`
+}
+
+type ExecuteMsgChangeOwner struct {
+	Address   string `json:"address"`
+	FileOwner string `json:"file_owner"`
+	NewOwner  string `json:"new_owner"`
 }
 
 // ToString returns a string representation of the message


### PR DESCRIPTION
this PR passes the filetree message `changeOwner` using the code refactored in https://github.com/JackalLabs/mulberry/pull/25