### PR TITLE
relay add/remove/resetEditors from EVM to Jackal

### DIFF
--- a/forge/src/Jackal.sol
+++ b/forge/src/Jackal.sol
@@ -25,6 +25,9 @@ abstract contract Jackal {
     event RemovedViewers(address from, string viewer_ids, string for_address, string file_owner);
     event ResetViewers(address from, string for_address, string file_owner);
     event ChangedOwner(address from, string for_address, string file_owner, string new_owner);
+    event AddedEditors(address from, string editor_ids, string editor_keys, string for_address, string file_owner);
+    event RemovedEditors(address from, string editor_ids, string for_address, string file_owner);
+    event ResetEditors(address from, string for_address, string file_owner);
 
     function getPrice() public view virtual returns (int256);
 
@@ -248,5 +251,49 @@ abstract contract Jackal {
         hasAllowance(from)
     {
         emit ChangedOwner(from, for_address, file_owner, new_owner);
+    }
+
+    function addEditors(
+        string memory editor_ids,
+        string memory editor_keys,
+        string memory for_address,
+        string memory file_owner
+    ) public {
+        addEditorsFrom(msg.sender, editor_ids, editor_keys, for_address, file_owner);
+    }
+
+    function addEditorsFrom(
+        address from,
+        string memory editor_ids,
+        string memory editor_keys,
+        string memory for_address,
+        string memory file_owner
+    ) public validAddress hasAllowance(from) {
+        emit AddedEditors(from, editor_ids, editor_keys, for_address, file_owner);
+    }
+
+    function removeEditors(string memory editor_ids, string memory for_address, string memory file_owner) public {
+        removeEditorsFrom(msg.sender, editor_ids, for_address, file_owner);
+    }
+
+    function removeEditorsFrom(
+        address from,
+        string memory editor_ids,
+        string memory for_address,
+        string memory file_owner
+    ) public validAddress hasAllowance(from) {
+        emit RemovedEditors(from, editor_ids, for_address, file_owner);
+    }
+
+    function resetEditors(string memory for_address, string memory file_owner) public {
+        resetEditorsFrom(msg.sender, for_address, file_owner);
+    }
+
+    function resetEditorsFrom(address from, string memory for_address, string memory file_owner)
+        public
+        validAddress
+        hasAllowance(from)
+    {
+        emit ResetEditors(from, for_address, file_owner);
     }
 }

--- a/forge/src/JackalInterface.sol
+++ b/forge/src/JackalInterface.sol
@@ -82,4 +82,26 @@ interface JackalInterface {
     function changeOwner(string memory for_address, string memory file_owner, string memory new_owner) external;
     function changeOwnerFrom(address from, string memory for_address, string memory file_owner, string memory new_owner)
         external;
+    function addEditors(
+        string memory editor_ids,
+        string memory editor_keys,
+        string memory for_address,
+        string memory file_owner
+    ) external;
+    function addEditorsFrom(
+        address from,
+        string memory editor_ids,
+        string memory editor_keys,
+        string memory for_address,
+        string memory file_owner
+    ) external;
+    function removeEditors(string memory editor_ids, string memory for_address, string memory file_owner) external;
+    function removeEditorsFrom(
+        address from,
+        string memory editor_ids,
+        string memory for_address,
+        string memory file_owner
+    ) external;
+    function resetEditors(string memory for_address, string memory file_owner) external;
+    function resetEditorsFrom(address from, string memory for_address, string memory file_owner) external;
 }

--- a/relay/abi.json
+++ b/relay/abi.json
@@ -14,6 +14,67 @@
   },
   {
     "type": "function",
+    "name": "addEditors",
+    "inputs": [
+      {
+        "name": "editor_ids",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "editor_keys",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "for_address",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "file_owner",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "addEditorsFrom",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "editor_ids",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "editor_keys",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "for_address",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "file_owner",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
     "name": "addViewers",
     "inputs": [
       {
@@ -601,6 +662,57 @@
   },
   {
     "type": "function",
+    "name": "removeEditors",
+    "inputs": [
+      {
+        "name": "editor_ids",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "for_address",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "file_owner",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "removeEditorsFrom",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "editor_ids",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "for_address",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "file_owner",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
     "name": "removeViewers",
     "inputs": [
       {
@@ -713,6 +825,47 @@
   },
   {
     "type": "function",
+    "name": "resetEditors",
+    "inputs": [
+      {
+        "name": "for_address",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "file_owner",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "resetEditorsFrom",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "for_address",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "file_owner",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
     "name": "resetViewers",
     "inputs": [
       {
@@ -751,6 +904,43 @@
     ],
     "outputs": [],
     "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "AddedEditors",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "editor_ids",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      },
+      {
+        "name": "editor_keys",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      },
+      {
+        "name": "for_address",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      },
+      {
+        "name": "file_owner",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      }
+    ],
+    "anonymous": false
   },
   {
     "type": "event",
@@ -1051,6 +1241,37 @@
   },
   {
     "type": "event",
+    "name": "RemovedEditors",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "editor_ids",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      },
+      {
+        "name": "for_address",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      },
+      {
+        "name": "file_owner",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
     "name": "RemovedViewers",
     "inputs": [
       {
@@ -1113,6 +1334,31 @@
         "type": "uint64",
         "indexed": false,
         "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ResetEditors",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "for_address",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      },
+      {
+        "name": "file_owner",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
       }
     ],
     "anonymous": false

--- a/relay/types.go
+++ b/relay/types.go
@@ -107,3 +107,24 @@ type ChangedOwner struct {
 	FileOwner  string
 	NewOwner   string
 }
+
+type AddedEditors struct {
+	From       common.Address
+	EditorIds  string
+	EditorKeys string
+	ForAddress string
+	FileOwner  string
+}
+
+type RemovedEditors struct {
+	From       common.Address
+	EditorIds  string
+	ForAddress string
+	FileOwner  string
+}
+
+type ResetEditors struct {
+	From       common.Address
+	ForAddress string
+	FileOwner  string
+}

--- a/types/messages.go
+++ b/types/messages.go
@@ -13,6 +13,9 @@ type ExecuteMsg struct {
 	RemoveViewers     *ExecuteMsgRemoveViewers     `json:"remove_viewers,omitempty"`
 	ResetViewers      *ExecuteMsgResetViewers      `json:"reset_viewers,omitempty"`
 	ChangeOwner       *ExecuteMsgChangeOwner       `json:"change_owner,omitempty"`
+	AddEditors        *ExecuteMsgAddEditors        `json:"add_editors,omitempty"`
+	RemoveEditors     *ExecuteMsgRemoveEditors     `json:"remove_editors,omitempty"`
+	ResetEditors      *ExecuteMsgResetEditors      `json:"reset_editors,omitempty"`
 }
 
 type ExecuteMsgPostKey struct {
@@ -92,6 +95,24 @@ type ExecuteMsgChangeOwner struct {
 	Address   string `json:"address"`
 	FileOwner string `json:"file_owner"`
 	NewOwner  string `json:"new_owner"`
+}
+
+type ExecuteMsgAddEditors struct {
+	EditorIds  string `json:"editor_ids"`
+	EditorKeys string `json:"editor_keys"`
+	Address    string `json:"address"`
+	FileOwner  string `json:"file_owner"`
+}
+
+type ExecuteMsgRemoveEditors struct {
+	EditorIds string `json:"editor_ids"`
+	Address   string `json:"address"`
+	FileOwner string `json:"file_owner"`
+}
+
+type ExecuteMsgResetEditors struct {
+	Address   string `json:"address"`
+	FileOwner string `json:"file_owner"`
 }
 
 // ToString returns a string representation of the message


### PR DESCRIPTION
this PR adds code to pass `addEditors`, `removeEditors`, and `resetEditors`. no unit tests yet.

after this PR is merged, all storage and filetree messages listed [here](https://github.com/JackalLabs/canine-chain/blob/evm/wasmbinding/bindings/msg.go) will be successfully passed.