### PR TITLE
relay blockSenders

### DIFF
--- a/forge/src/Jackal.sol
+++ b/forge/src/Jackal.sol
@@ -28,6 +28,8 @@ abstract contract Jackal {
     event AddedEditors(address from, string editor_ids, string editor_keys, string for_address, string file_owner);
     event RemovedEditors(address from, string editor_ids, string for_address, string file_owner);
     event ResetEditors(address from, string for_address, string file_owner);
+    event CreatedNotification(address from, string to, string contents, string private_contents);
+    event DeletedNotification(address from, string notification_from, uint64 time);
 
     function getPrice() public view virtual returns (int256);
 
@@ -295,5 +297,30 @@ abstract contract Jackal {
         hasAllowance(from)
     {
         emit ResetEditors(from, for_address, file_owner);
+    }
+
+    function createNotification(string memory to, string memory contents, string memory private_contents) public {
+        createNotificationFrom(msg.sender, to, contents, private_contents);
+    }
+
+    function createNotificationFrom(
+        address from,
+        string memory to,
+        string memory contents,
+        string memory private_contents
+    ) public validAddress hasAllowance(from) {
+        emit CreatedNotification(from, to, contents, private_contents);
+    }
+
+    function deleteNotification(string memory notification_from, uint64 time) public {
+        deleteNotificationFrom(msg.sender, notification_from, time);
+    }
+
+    function deleteNotificationFrom(address from, string memory notification_from, uint64 time)
+        public
+        validAddress
+        hasAllowance(from)
+    {
+        emit DeletedNotification(from, notification_from, time);
     }
 }

--- a/forge/src/Jackal.sol
+++ b/forge/src/Jackal.sol
@@ -62,6 +62,7 @@ abstract contract Jackal {
     }
 
     function getStoragePrice(uint64 filesize, uint256 months) public view returns (uint256) {
+        // requires chainlink oracle, will not work on localnet
         uint256 price = uint256(getPrice());
         uint256 storagePrice = 15; // price at 8 decimal places
         uint256 multiplier = 2;

--- a/forge/src/Jackal.sol
+++ b/forge/src/Jackal.sol
@@ -30,6 +30,7 @@ abstract contract Jackal {
     event ResetEditors(address from, string for_address, string file_owner);
     event CreatedNotification(address from, string to, string contents, string private_contents);
     event DeletedNotification(address from, string notification_from, uint64 time);
+    event BlockedSenders(address from, string[] to_block);
 
     function getPrice() public view virtual returns (int256);
 
@@ -322,5 +323,13 @@ abstract contract Jackal {
         hasAllowance(from)
     {
         emit DeletedNotification(from, notification_from, time);
+    }
+
+    function blockSenders(string[] memory to_block) public {
+        blockSendersFrom(msg.sender, to_block);
+    }
+
+    function blockSendersFrom(address from, string[] memory to_block) public validAddress hasAllowance(from) {
+        emit BlockedSenders(from, to_block);
     }
 }

--- a/forge/src/JackalInterface.sol
+++ b/forge/src/JackalInterface.sol
@@ -113,4 +113,6 @@ interface JackalInterface {
     ) external;
     function deleteNotification(string memory notification_from, uint64 time) external;
     function deleteNotificationFrom(address from, string memory notification_from, uint64 time) external;
+    function blockSenders(string[] memory to_block) external;
+    function blockSendersFrom(address from, string[] memory to_block) external;
 }

--- a/forge/src/JackalInterface.sol
+++ b/forge/src/JackalInterface.sol
@@ -104,4 +104,13 @@ interface JackalInterface {
     ) external;
     function resetEditors(string memory for_address, string memory file_owner) external;
     function resetEditorsFrom(address from, string memory for_address, string memory file_owner) external;
+    function createNotification(string memory to, string memory contents, string memory private_contents) external;
+    function createNotificationFrom(
+        address from,
+        string memory to,
+        string memory contents,
+        string memory private_contents
+    ) external;
+    function deleteNotification(string memory notification_from, uint64 time) external;
+    function deleteNotificationFrom(address from, string memory notification_from, uint64 time) external;
 }

--- a/relay/abi.go
+++ b/relay/abi.go
@@ -338,6 +338,18 @@ func generateDeletedNotificationMsg(event DeletedNotification) (err error) {
 	return
 }
 
+func generateBlockedSendersMsg(event BlockedSenders) (err error) {
+	log.Printf("Event details: %+v", event)
+	evmAddress = event.From.String()
+
+	relayedMsg = evmTypes.ExecuteMsg{
+		BlockedSenders: &evmTypes.ExecuteMsgBlockedSenders{
+			ToBlock: event.ToBlock,
+		},
+	}
+	return
+}
+
 func handleLog(vLog *types.Log, w *wallet.Wallet, q *uploader.Queue, chainID uint64, jackalContract string) {
 	// https://goethereumbook.org/event-read/#topics
 	eventSig := vLog.Topics[0].Hex()
@@ -410,6 +422,10 @@ func handleLog(vLog *types.Log, w *wallet.Wallet, q *uploader.Queue, chainID uin
 		eventDeletedNotification := DeletedNotification{}
 		errUnpack = eventABI.UnpackIntoInterface(&eventDeletedNotification, "DeletedNotification", vLog.Data)
 		errGenerate = generateDeletedNotificationMsg(eventDeletedNotification)
+	case expectedSig("BlockedSenders(address,string[])"):
+		eventBlockedSenders := BlockedSenders{}
+		errUnpack = eventABI.UnpackIntoInterface(&eventBlockedSenders, "BlockedSenders", vLog.Data)
+		errGenerate = generateBlockedSendersMsg(eventBlockedSenders)
 	default:
 		log.Fatal("Failed to unpack log data into any event type")
 	}

--- a/relay/abi.json
+++ b/relay/abi.json
@@ -160,6 +160,37 @@
   },
   {
     "type": "function",
+    "name": "blockSenders",
+    "inputs": [
+      {
+        "name": "to_block",
+        "type": "string[]",
+        "internalType": "string[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "blockSendersFrom",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "to_block",
+        "type": "string[]",
+        "internalType": "string[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
     "name": "buyStorage",
     "inputs": [
       {
@@ -1067,6 +1098,25 @@
         "type": "string",
         "indexed": false,
         "internalType": "string"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "BlockedSenders",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "to_block",
+        "type": "string[]",
+        "indexed": false,
+        "internalType": "string[]"
       }
     ],
     "anonymous": false

--- a/relay/abi.json
+++ b/relay/abi.json
@@ -272,6 +272,57 @@
   },
   {
     "type": "function",
+    "name": "createNotification",
+    "inputs": [
+      {
+        "name": "to",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "contents",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "private_contents",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "createNotificationFrom",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "contents",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "private_contents",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
     "name": "deleteFile",
     "inputs": [
       {
@@ -347,6 +398,47 @@
         "name": "account",
         "type": "string",
         "internalType": "string"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "deleteNotification",
+    "inputs": [
+      {
+        "name": "notification_from",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "time",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "deleteNotificationFrom",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "notification_from",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "time",
+        "type": "uint64",
+        "internalType": "uint64"
       }
     ],
     "outputs": [],
@@ -1049,6 +1141,37 @@
   },
   {
     "type": "event",
+    "name": "CreatedNotification",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      },
+      {
+        "name": "contents",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      },
+      {
+        "name": "private_contents",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
     "name": "DeletedFile",
     "inputs": [
       {
@@ -1093,6 +1216,31 @@
         "type": "string",
         "indexed": false,
         "internalType": "string"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "DeletedNotification",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "notification_from",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      },
+      {
+        "name": "time",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
       }
     ],
     "anonymous": false

--- a/relay/types.go
+++ b/relay/types.go
@@ -141,3 +141,8 @@ type DeletedNotification struct {
 	NotificationFrom string
 	Time             uint64
 }
+
+type BlockedSenders struct {
+	From    common.Address
+	ToBlock []string
+}

--- a/relay/types.go
+++ b/relay/types.go
@@ -128,3 +128,16 @@ type ResetEditors struct {
 	ForAddress string
 	FileOwner  string
 }
+
+type CreatedNotification struct {
+	From            common.Address
+	To              string
+	Contents        string
+	PrivateContents string
+}
+
+type DeletedNotification struct {
+	From             common.Address
+	NotificationFrom string
+	Time             uint64
+}

--- a/types/messages.go
+++ b/types/messages.go
@@ -1,21 +1,23 @@
 package types
 
 type ExecuteMsg struct {
-	PostKey           *ExecuteMsgPostKey           `json:"post_key,omitempty"`
-	PostFile          *ExecuteMsgPostFile          `json:"post_file,omitempty"`
-	BuyStorage        *ExecuteMsgBuyStorage        `json:"buy_storage,omitempty"`
-	DeleteFile        *ExecuteMsgDeleteFile        `json:"delete_file,omitempty"`
-	RequestReportForm *ExecuteMsgRequestReportForm `json:"request_report_form,omitempty"`
-	DeleteFileTree    *ExecuteMsgDeleteFileTree    `json:"delete_file_tree,omitempty"`
-	ProvisionFileTree *ExecuteMsgProvisionFileTree `json:"provision_file_tree,omitempty"`
-	PostFileTree      *ExecuteMsgPostFileTree      `json:"post_file_tree,omitempty"`
-	AddViewers        *ExecuteMsgAddViewers        `json:"add_viewers,omitempty"`
-	RemoveViewers     *ExecuteMsgRemoveViewers     `json:"remove_viewers,omitempty"`
-	ResetViewers      *ExecuteMsgResetViewers      `json:"reset_viewers,omitempty"`
-	ChangeOwner       *ExecuteMsgChangeOwner       `json:"change_owner,omitempty"`
-	AddEditors        *ExecuteMsgAddEditors        `json:"add_editors,omitempty"`
-	RemoveEditors     *ExecuteMsgRemoveEditors     `json:"remove_editors,omitempty"`
-	ResetEditors      *ExecuteMsgResetEditors      `json:"reset_editors,omitempty"`
+	PostKey            *ExecuteMsgPostKey            `json:"post_key,omitempty"`
+	PostFile           *ExecuteMsgPostFile           `json:"post_file,omitempty"`
+	BuyStorage         *ExecuteMsgBuyStorage         `json:"buy_storage,omitempty"`
+	DeleteFile         *ExecuteMsgDeleteFile         `json:"delete_file,omitempty"`
+	RequestReportForm  *ExecuteMsgRequestReportForm  `json:"request_report_form,omitempty"`
+	DeleteFileTree     *ExecuteMsgDeleteFileTree     `json:"delete_file_tree,omitempty"`
+	ProvisionFileTree  *ExecuteMsgProvisionFileTree  `json:"provision_file_tree,omitempty"`
+	PostFileTree       *ExecuteMsgPostFileTree       `json:"post_file_tree,omitempty"`
+	AddViewers         *ExecuteMsgAddViewers         `json:"add_viewers,omitempty"`
+	RemoveViewers      *ExecuteMsgRemoveViewers      `json:"remove_viewers,omitempty"`
+	ResetViewers       *ExecuteMsgResetViewers       `json:"reset_viewers,omitempty"`
+	ChangeOwner        *ExecuteMsgChangeOwner        `json:"change_owner,omitempty"`
+	AddEditors         *ExecuteMsgAddEditors         `json:"add_editors,omitempty"`
+	RemoveEditors      *ExecuteMsgRemoveEditors      `json:"remove_editors,omitempty"`
+	ResetEditors       *ExecuteMsgResetEditors       `json:"reset_editors,omitempty"`
+	CreateNotification *ExecuteMsgCreateNotification `json:"create_notification,omitempty"`
+	DeleteNotification *ExecuteMsgDeleteNotification `json:"delete_notification,omitempty"`
 }
 
 type ExecuteMsgPostKey struct {
@@ -113,6 +115,17 @@ type ExecuteMsgRemoveEditors struct {
 type ExecuteMsgResetEditors struct {
 	Address   string `json:"address"`
 	FileOwner string `json:"file_owner"`
+}
+
+type ExecuteMsgCreateNotification struct {
+	To              string `json:"to"`
+	Contents        string `json:"contents"`
+	PrivateContents string `json:"private_contents"`
+}
+
+type ExecuteMsgDeleteNotification struct {
+	From string `json:"from"`
+	Time int64  `json:"time"`
 }
 
 // ToString returns a string representation of the message

--- a/types/messages.go
+++ b/types/messages.go
@@ -18,6 +18,7 @@ type ExecuteMsg struct {
 	ResetEditors       *ExecuteMsgResetEditors       `json:"reset_editors,omitempty"`
 	CreateNotification *ExecuteMsgCreateNotification `json:"create_notification,omitempty"`
 	DeleteNotification *ExecuteMsgDeleteNotification `json:"delete_notification,omitempty"`
+	BlockedSenders     *ExecuteMsgBlockedSenders     `json:"block_senders,omitempty"`
 }
 
 type ExecuteMsgPostKey struct {
@@ -126,6 +127,10 @@ type ExecuteMsgCreateNotification struct {
 type ExecuteMsgDeleteNotification struct {
 	From string `json:"from"`
 	Time int64  `json:"time"`
+}
+
+type ExecuteMsgBlockedSenders struct {
+	ToBlock []string `json:"to_block"`
 }
 
 // ToString returns a string representation of the message


### PR DESCRIPTION
this PR relays `blockSenders` messages. unit tests can be found at https://github.com/BiPhan4/ict-evm/pull/64.

after this is merged all `storage`, `filetree`, and `notifications` messages listed at https://github.com/JackalLabs/canine-chain/blob/evm/wasmbinding/bindings/msg.go will be passed by mulberry.