### PR TITLE
differentiate networks in logs

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -117,26 +117,26 @@ jackal_config:
     contract: jkl163jzm5mmy29ke6ecn4m5evqk9lfhxwne3vzjpe3lpyc33yz5uy0skhhxm8
 networks_config:
     - name: Sepolia
-      rpc: https://ethereum-sepolia-rpc.publicnode.com
-      ws: wss://ethereum-sepolia-rpc.publicnode.com
+      rpc: https://rpc.sepolia.dev
+      ws: wss://rpc.sepolia.dev
       contract: 0x093BB75ba20F4fe05c31a63ac42B93252C31aE02
       chain_id: 11155111
       finality: 2
     - name: Base Sepolia
-      rpc: https://base-sepolia-rpc.publicnode.com
-      ws: wss://base-sepolia-rpc.publicnode.com
+      rpc: https://sepolia.base.org
+      ws: wss://sepolia.base.org
       contract: 0x5d26f092717A538B446A301C2121D6C68157467C
       chain_id: 84532
       finality: 2
     - name: OP Sepolia
-      rpc: https://optimism-sepolia-rpc.publicnode.com
-      ws: wss://optimism-sepolia-rpc.publicnode.com
+      rpc: https://sepolia.optimism.io
+      ws: wss://sepolia.optimism.io
       contract: 0xA3FF0a3e8edCd1c1BefBa6e48e847DB9feF82CA2
       chain_id: 11155420
       finality: 2
     - name: Polygon Amoy
-      rpc: https://polygon-amoy-bor-rpc.publicnode.com
-      ws: wss://polygon-amoy-bor-rpc.publicnode.com
+      rpc: https://rpc-amoy.polygon.technology
+      ws: wss://rpc-amoy.polygon.technology
       contract: 0x5d26f092717A538B446A301C2121D6C68157467C
       chain_id: 80002
       finality: 2

--- a/relay/eth.go
+++ b/relay/eth.go
@@ -17,7 +17,7 @@ import (
 )
 
 func (a *App) ListenToEthereumNetwork(network config.NetworkConfig, wg *sync.WaitGroup) {
-	log.Printf("Now listening to %s...", network.Name)
+	log.Printf("Connecting to %s", network.Name)
 
 	jackalContract := a.cfg.JackalConfig.Contract
 
@@ -39,6 +39,7 @@ func (a *App) ListenToEthereumNetwork(network config.NetworkConfig, wg *sync.Wai
 		_, err := ethclient.Dial(network.RPC)
 		if err != nil {
 			log.Printf("Failed to connect to the Ethereum RPC client, retrying in 5 seconds: %v", err)
+			log.Printf("rpc client: %s", network.RPC)
 			time.Sleep(5 * time.Second)
 			continue
 		}
@@ -58,6 +59,7 @@ func (a *App) ListenToEthereumNetwork(network config.NetworkConfig, wg *sync.Wai
 		sub, logs, err = subscribeLogs(wsClient, query)
 		if err != nil {
 			log.Printf("Failed to subscribe, retrying in 5 seconds: %v", err)
+			log.Printf("ws client: %s", network.WS)
 			if wsClient != nil {
 				wsClient.Close()
 			}
@@ -65,7 +67,7 @@ func (a *App) ListenToEthereumNetwork(network config.NetworkConfig, wg *sync.Wai
 			continue
 		}
 
-		log.Print("Ready to listen!")
+		log.Printf("Ready to listen on %s", network.Name)
 
 		// Listening loop
 		func() {


### PR DESCRIPTION
after these simple changes, logs look like
![image](https://github.com/user-attachments/assets/51f1addc-98fc-4e0b-bc46-fe8c1bf8b013)
so we no longer have to guess which network is erroring